### PR TITLE
use to_param for more Rails-compatible controllers

### DIFF
--- a/lib/gollum_rails/core.rb
+++ b/lib/gollum_rails/core.rb
@@ -193,6 +193,9 @@ module GollumRails
       @content ||= (@gollum_page.content || "")
     end
 
+    def to_param
+      name
+    end
 
     private
 

--- a/spec/gollum_rails/page_spec.rb
+++ b/spec/gollum_rails/page_spec.rb
@@ -77,6 +77,10 @@ describe "Gollum Page" do
         @rr.save
         expect(@rr.url) =="Goole"
       end
+      it "has correct to_param" do
+        @rr.save
+        expect(@rr.to_param).to eq(@rr.name)
+      end
     end
     describe "the update of a page" do
       before :each do


### PR DESCRIPTION
Right now I have to use something like
```
    if @page.update_attributes(attributes)
      redirect_to page_path(@page.name)
    end
```
in controller that manages Gollum. It would be nice to be able to use Rails-like ```redirect_to @page```.

This pull request adds this.